### PR TITLE
Updated README code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example snippet on frontend could look like:
 
     <?php
 
-    require 'fitbitphp.php'
+    require 'fitbitphp.php';
 
     $fitbit = new FitBitPHP(FITBIT_KEY, FITBIT_SECRET);
 
@@ -37,7 +37,7 @@ Note, that unconditional call to 'initSession' in each page will completely hide
 
 Second, if you want to implement some API calls on user's behalf later (say daemon with no frontend), when you've already stored OAuth credentials somewhere, you could do exactly that:
 
-    require 'fitbitphp.php'
+    require 'fitbitphp.php';
 
     $fitbit = new FitBitPHP(FITBIT_KEY, FITBIT_SECRET);
     $fitbit->setOAuthDetails('token_stored_for_user', 'secret_stored_for_user');
@@ -51,7 +51,7 @@ Second, if you want to implement some API calls on user's behalf later (say daem
 
 If you want to fetch data without complete OAuth workflow, only using consumer_key without access_token, you can do that also (check which endpoints are okey with such calls on Fitbit API documentation):
 
-    require 'fitbitphp.php'
+    require 'fitbitphp.php';
 
     $fitbit = new FitBitPHP(FITBIT_KEY, FITBIT_SECRET);
 


### PR DESCRIPTION
All the sample code had source code of:

``` php
<?php

require 'api/fitbitphp.php'

$fitbit = new FitBitPHP("57521d64c4044becab73bfc5f2e6578e", "a5b63f9b6e9c4601893dae54c87ab78c");

$fitbit->initSession('http://example.com/callback.php');
$xml = $fitbit->getProfile();

print_r($xml);
?>
```

There needs to be a semi-colon at the end of the require call.

``` php
require 'api/fitbitphp.php';
```
