### PR TITLE
Use HTTPS (SSL) by default when communicating with the Fitbit API

### DIFF
--- a/fitbitphp.php
+++ b/fitbitphp.php
@@ -95,7 +95,7 @@ class FitBitPHP
      * @param string $apiHost API host, i.e. api.fitbit.com (do you know any others?)
      * @param string $authHost Auth host, i.e. www.fitbit.com
      */
-    public function setEndpointBase($apiHost, $authHost, $https = true, $httpsApi = false)
+    public function setEndpointBase($apiHost, $authHost, $https = true, $httpsApi = true)
     {
         $this->apiHost = $apiHost;
         $this->authHost = $authHost;
@@ -103,7 +103,7 @@ class FitBitPHP
         $this->initUrls($https, $httpsApi);
     }
 
-    private function initUrls($https = true, $httpsApi = false)
+    private function initUrls($https = true, $httpsApi = true)
     {
 
         if ($httpsApi)


### PR DESCRIPTION
On Monday, November 3, 2014, connections to api.fitbit.com will be restricted to HTTPS connections only. TLS ("SSL") will be required to use all api.fitbit.com endpoints, including all steps of OAuth.

This change brings the library in compliance with this new requirement.
